### PR TITLE
Add parameters decorators usage

### DIFF
--- a/tests/test_functions/test_asyncify.py
+++ b/tests/test_functions/test_asyncify.py
@@ -1,0 +1,26 @@
+import anyio
+
+from asyncer import asyncify
+
+
+def test_decorator():
+    @asyncify
+    def func(a: int):
+        return a
+
+    assert anyio.run(func, 1) == 1
+
+
+def test_decorator_with_params():
+    @asyncify()
+    def func(a: int):
+        return a
+
+    assert anyio.run(func, 1) == 1
+
+
+def test_inline():
+    def func(a: int):
+        return a
+
+    assert anyio.run(asyncify(func), 1) == 1

--- a/tests/test_functions/test_asyncify.py
+++ b/tests/test_functions/test_asyncify.py
@@ -1,5 +1,4 @@
 import anyio
-
 from asyncer import asyncify
 
 

--- a/tests/test_functions/test_runnify.py
+++ b/tests/test_functions/test_runnify.py
@@ -1,6 +1,5 @@
 import anyio
-
-from asyncer import runnify, asyncify
+from asyncer import asyncify, runnify
 
 
 def test_decorator():

--- a/tests/test_functions/test_runnify.py
+++ b/tests/test_functions/test_runnify.py
@@ -1,0 +1,26 @@
+import anyio
+
+from asyncer import runnify, asyncify
+
+
+def test_decorator():
+    @runnify
+    async def func(a: int):
+        return a
+
+    assert anyio.run(asyncify(func), 1) == 1
+
+
+def test_decorator_with_params():
+    @runnify()
+    async def func(a: int):
+        return a
+
+    assert anyio.run(asyncify(func), 1) == 1
+
+
+def test_inline():
+    async def func(a: int):
+        return a
+
+    assert anyio.run(asyncify(runnify(func)), 1) == 1

--- a/tests/test_functions/test_syncify.py
+++ b/tests/test_functions/test_syncify.py
@@ -1,6 +1,5 @@
 import anyio
-
-from asyncer import syncify, asyncify
+from asyncer import asyncify, syncify
 
 
 def test_decorator():

--- a/tests/test_functions/test_syncify.py
+++ b/tests/test_functions/test_syncify.py
@@ -1,0 +1,26 @@
+import anyio
+
+from asyncer import syncify, asyncify
+
+
+def test_decorator():
+    @syncify
+    async def func(a: int):
+        return a
+
+    assert anyio.run(asyncify(func), 1) == 1
+
+
+def test_decorator_with_params():
+    @syncify()
+    async def func(a: int):
+        return a
+
+    assert anyio.run(asyncify(func), 1) == 1
+
+
+def test_inline():
+    async def func(a: int):
+        return a
+
+    assert anyio.run(asyncify(syncify(func)), 1) == 1


### PR DESCRIPTION
I know, that the main goal of this package is a calling sync/async functions from async/sync code.
This reason, I suppose, there no decorators usecases in documentation (but functions' signature is pretty close to decorators with a `Calling` at first arg).
But this usacase still can be suitable for updating legacy code base with migration from sync application to an async one (it was usefull for me at least).
The current codebase allowa you to use something like
```python
from asyncer import asyncify

@asyncify
def func(): ....
```
But, you can't pass additional arguments to it.

So, I update all functions to allowa usage with these cases:
```python
from asyncer import asyncify

asyncify(func)(...)

@asyncify
def func(): ....

@asyncify(cancellable=True)
def func(): ...
```

It should improve DX of library usage and it costs nothing to It. All functionality is tested, annotations works fine too.
