### PR TITLE
fix: delete deprecation warning of anyio in asyncify decorator

### DIFF
--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -368,7 +368,9 @@ def asyncify(
         ) -> T_Retval:
             partial_f = functools.partial(function, *args, **kwargs)
             return await anyio.to_thread.run_sync(
-                partial_f, abandon_on_cancel=cancellable, limiter=limiter
+                partial_f,
+                abandon_on_cancel=cancellable, # type: ignore[call-arg]
+                limiter=limiter
             )
 
         return wrapper

--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -1,7 +1,7 @@
 import functools
-from importlib.metadata import version as module_version
 import sys
 from importlib import import_module
+from importlib.metadata import version as module_version
 from typing import (
     Any,
     Awaitable,
@@ -24,8 +24,7 @@ import sniffio
 from anyio._core._eventloop import threadlocals
 from anyio.abc import TaskGroup as _TaskGroup
 
-
-ANYIO_VERSION = tuple(int(num) for num in module_version('anyio').split('.'))
+ANYIO_VERSION = tuple(int(num) for num in module_version("anyio").split("."))
 
 
 # This was obtained with: from anyio._core._eventloop import get_asynclib
@@ -363,6 +362,7 @@ def asyncify(
     """
 
     if ANYIO_VERSION >= (4, 1, 0):
+
         async def wrapper(
             *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
         ) -> T_Retval:
@@ -370,14 +370,15 @@ def asyncify(
             return await anyio.to_thread.run_sync(
                 partial_f, abandon_on_cancel=cancellable, limiter=limiter
             )
+
         return wrapper
 
     async def wrapper(
-            *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
-        ) -> T_Retval:
-            partial_f = functools.partial(function, *args, **kwargs)
-            return await anyio.to_thread.run_sync(
-                partial_f, cancellable=cancellable, limiter=limiter
-            )
+        *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
+    ) -> T_Retval:
+        partial_f = functools.partial(function, *args, **kwargs)
+        return await anyio.to_thread.run_sync(
+            partial_f, cancellable=cancellable, limiter=limiter
+        )
 
     return wrapper

--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -369,8 +369,8 @@ def asyncify(
             partial_f = functools.partial(function, *args, **kwargs)
             return await anyio.to_thread.run_sync(
                 partial_f,
-                abandon_on_cancel=cancellable,  # type: ignore[call-arg]
-                limiter=limiter,
+                abandon_on_cancel=cancellable, # type: ignore[call-arg,unused-ignore]
+                limiter=limiter
             )
 
         return wrapper

--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -369,8 +369,8 @@ def asyncify(
             partial_f = functools.partial(function, *args, **kwargs)
             return await anyio.to_thread.run_sync(
                 partial_f,
-                abandon_on_cancel=cancellable, # type: ignore[call-arg]
-                limiter=limiter
+                abandon_on_cancel=cancellable,  # type: ignore[call-arg]
+                limiter=limiter,
             )
 
         return wrapper

--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -369,8 +369,8 @@ def asyncify(
             partial_f = functools.partial(function, *args, **kwargs)
             return await anyio.to_thread.run_sync(
                 partial_f,
-                abandon_on_cancel=cancellable, # type: ignore[call-arg,unused-ignore]
-                limiter=limiter
+                abandon_on_cancel=cancellable,  # type: ignore[call-arg,unused-ignore]
+                limiter=limiter,
             )
 
         return wrapper

--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -1,4 +1,5 @@
 import functools
+from importlib.metadata import version as module_version
 import sys
 from importlib import import_module
 from typing import (
@@ -22,6 +23,9 @@ import anyio
 import sniffio
 from anyio._core._eventloop import threadlocals
 from anyio.abc import TaskGroup as _TaskGroup
+
+
+ANYIO_VERSION = tuple(int(num) for num in module_version('anyio').split('.'))
 
 
 # This was obtained with: from anyio._core._eventloop import get_asynclib
@@ -358,12 +362,22 @@ def asyncify(
     and returns the result.
     """
 
+    if ANYIO_VERSION >= (4, 1, 0):
+        async def wrapper(
+            *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
+        ) -> T_Retval:
+            partial_f = functools.partial(function, *args, **kwargs)
+            return await anyio.to_thread.run_sync(
+                partial_f, abandon_on_cancel=cancellable, limiter=limiter
+            )
+        return wrapper
+
     async def wrapper(
-        *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
-    ) -> T_Retval:
-        partial_f = functools.partial(function, *args, **kwargs)
-        return await anyio.to_thread.run_sync(
-            partial_f, cancellable=cancellable, limiter=limiter
-        )
+            *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
+        ) -> T_Retval:
+            partial_f = functools.partial(function, *args, **kwargs)
+            return await anyio.to_thread.run_sync(
+                partial_f, cancellable=cancellable, limiter=limiter
+            )
 
     return wrapper

--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -373,7 +373,7 @@ def asyncify(
 
         return wrapper
 
-    async def wrapper(
+    async def wrapper(  # type: ignore[no-redef]
         *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
     ) -> T_Retval:
         partial_f = functools.partial(function, *args, **kwargs)


### PR DESCRIPTION
Deleted deprecation warning for `anyio>=4.1.0`.
Using `asyncify` shows warning message:
```bash
.venv/lib/python3.11/site-packages/asyncer/_main.py:365: DeprecationWarning: The `cancellable=` keyword argument to `anyio.to_thread.run_sync` is deprecated since AnyIO 4.1.0; use `abandon_on_cancel=` instead
```

This PR fixed it