### PR TITLE
🔧 Add URLs to `pyproject.toml`, show up in PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
 Homepage = "https://github.com/fastapi/asyncer"
 Documentation = "https://asyncer.tiangolo.com"
 Repository = "https://github.com/fastapi/asyncer"
+Issues = "https://github.com/fastapi/asyncer/issues"
+Changelog = "https://asyncer.tiangolo.com/release-notes/"
 
 [tool.pdm]
 version = { source = "file", path = "asyncer/__init__.py" }


### PR DESCRIPTION
🔧 Add URLs to `pyproject.toml`, show up in PyPI