### PR TITLE
🐛 Fix Python3.11+ raises `ModuleNotFoundError: No module named typing_extensions`

### DIFF
--- a/asyncer/_compat.py
+++ b/asyncer/_compat.py
@@ -1,12 +1,17 @@
 # AnyIO 4.1.0 renamed cancellable to abandon_on_cancel
 import importlib
 import importlib.metadata
+import sys
 from typing import Callable, TypeVar, Union
 
 import anyio
 import anyio.to_thread
 from anyio import CapacityLimiter
-from typing_extensions import TypeVarTuple, Unpack
+
+if sys.version_info >= (3, 11):
+    from typing import TypeVarTuple, Unpack
+else:
+    from typing_extensions import TypeVarTuple, Unpack
 
 ANYIO_VERSION = importlib.metadata.version("anyio")
 

--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -135,7 +135,7 @@ class TaskGroup(_TaskGroup):
         async with asyncer.create_task_group() as task_group:
             result1 = task_group.soonify(do_work)(name="task 1")
             result2 = task_group.soonify(do_work)(name="task 2")
-            await anyio.sleep(0)
+            await anyio.lowlevel.checkpoint()
             if not result1.pending:
                 print(result1.value)
             if not result2.pending:

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,0 @@
-[virtualenvs]
-create = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "anyio >=3.4.0,<5.0",
-    "typing_extensions >=4.8.0; python_version < '3.10'"
+    "typing_extensions >=4.8.0; python_version < '3.11'"
 ]
 
 [project.urls]


### PR DESCRIPTION
## How to reproduce:
```bash
mkdir temp
cd temp
python3.11 -m venv venv
source venv/*/activate
pip install asyncer
python -c 'import asyncer'
```
BTW: I changed `anyio.sleep(0)` to `anyio.lowlevel.checkpoint` as `ruff check --extend-select=ASYNC` suggested. And remove the file `poetry.toml` as no longer need it.