### PR TITLE
Fix docstring example in _main.py TaskGroup from .pending to .ready

### DIFF
--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -136,9 +136,9 @@ class TaskGroup(_TaskGroup):
             result1 = task_group.soonify(do_work)(name="task 1")
             result2 = task_group.soonify(do_work)(name="task 2")
             await anyio.sleep(0)
-            if not result1.pending:
+            if result1.ready:
                 print(result1.value)
-            if not result2.pending:
+            if result2.ready:
                 print(result2.value)
         ```
 


### PR DESCRIPTION
The docstring in TaskGroup incorrectly gave an example like `if not result1.pending` but SoonValue does not have a pending attribute. The example should check `if result1.ready` instead.