### PR TITLE
🩺 Take the GH badge only from pushes to the `main` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 </p>
 <p align="center">
 <a href="https://github.com/fastapi/asyncer/actions?query=workflow%3ATest+event%3Apush+branch%3Amain" target="_blank">
-    <img src="https://github.com/fastapi/asyncer/workflows/Test/badge.svg?event=push&branch=main" alt="Test">
+    <img src="https://github.com/fastapi/asyncer/actions/workflows/test.yml/badge.svg?event=push&branch=main" alt="Test">
 </a>
 <a href="https://github.com/fastapi/asyncer/actions?query=workflow%3APublish" target="_blank">
-    <img src="https://github.com/fastapi/asyncer/workflows/Publish/badge.svg" alt="Publish">
+    <img src="https://github.com/fastapi/asyncer/actions/workflows/publish.yml/badge.svg" alt="Publish">
 </a>
 <a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/asyncer" target="_blank">
     <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/asyncer.svg" alt="Coverage">

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
     <em>Asyncer, async and await, focused on developer experience.</em>
 </p>
 <p align="center">
-<a href="https://github.com/fastapi/asyncer/actions?query=workflow%3ATest" target="_blank">
-    <img src="https://github.com/fastapi/asyncer/workflows/Test/badge.svg" alt="Test">
+<a href="https://github.com/fastapi/asyncer/actions?query=workflow%3ATest+event%3Apush+branch%3Amain" target="_blank">
+    <img src="https://github.com/fastapi/asyncer/workflows/Test/badge.svg?event=push&branch=main" alt="Test">
 </a>
 <a href="https://github.com/fastapi/asyncer/actions?query=workflow%3APublish" target="_blank">
     <img src="https://github.com/fastapi/asyncer/workflows/Publish/badge.svg" alt="Publish">

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,10 @@
 </p>
 <p align="center">
 <a href="https://github.com/fastapi/asyncer/actions?query=workflow%3ATest+event%3Apush+branch%3Amain" target="_blank">
-    <img src="https://github.com/fastapi/asyncer/workflows/Test/badge.svg?event=push&branch=main" alt="Test">
+    <img src="https://github.com/fastapi/asyncer/actions/workflows/test.yml/badge.svg?event=push&branch=main" alt="Test">
 </a>
 <a href="https://github.com/fastapi/asyncer/actions?query=workflow%3APublish" target="_blank">
-    <img src="https://github.com/fastapi/asyncer/workflows/Publish/badge.svg" alt="Publish">
+    <img src="https://github.com/fastapi/asyncer/actions/workflows/publish.yml/badge.svg" alt="Publish">
 </a>
 <a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/asyncer" target="_blank">
     <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/asyncer.svg" alt="Coverage">

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@
     <em>Asyncer, async and await, focused on developer experience.</em>
 </p>
 <p align="center">
-<a href="https://github.com/fastapi/asyncer/actions?query=workflow%3ATest" target="_blank">
-    <img src="https://github.com/fastapi/asyncer/workflows/Test/badge.svg" alt="Test">
+<a href="https://github.com/fastapi/asyncer/actions?query=workflow%3ATest+event%3Apush+branch%3Amain" target="_blank">
+    <img src="https://github.com/fastapi/asyncer/workflows/Test/badge.svg?event=push&branch=main" alt="Test">
 </a>
 <a href="https://github.com/fastapi/asyncer/actions?query=workflow%3APublish" target="_blank">
     <img src="https://github.com/fastapi/asyncer/workflows/Publish/badge.svg" alt="Publish">


### PR DESCRIPTION
I noticed earlier today that the "Test" badge on https://asyncer.tiangolo.com/ and https://github.com/fastapi/asyncer/blob/main/README.md was red because some bot's PR had failed on its last test run. This PR ensures that the badge only looks at the latest push to `main` (similar to how it's currently done in [FastAPI](https://github.com/fastapi/fastapi/blob/master/README.md?plain=1#L8)).