### PR TITLE
👷 Update docs previews comment, single comment, add failure status

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -61,8 +61,8 @@ jobs:
         if: hashFiles('./site/*')
         id: deploy
         env:
-          PROJECT_NAME: typertiangolo
-          BRANCH: ${{ ( github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'master' && 'main' ) || ( github.event.workflow_run.head_sha ) }}
+          PROJECT_NAME: asyncer
+          BRANCH: ${{ ( github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'main' && 'main' ) || ( github.event.workflow_run.head_sha ) }}
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,7 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_ID: ${{ github.run_id }}
-
+          STATE: "pending"
       - name: Clean site
         run: |
           rm -rf ./site
@@ -61,13 +61,21 @@ jobs:
         if: hashFiles('./site/*')
         id: deploy
         env:
-          PROJECT_NAME: asyncer
-          BRANCH: ${{ ( github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'main' && 'main' ) || ( github.event.workflow_run.head_sha ) }}
+          PROJECT_NAME: typertiangolo
+          BRANCH: ${{ ( github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'master' && 'main' ) || ( github.event.workflow_run.head_sha ) }}
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy ./site --project-name=${{ env.PROJECT_NAME }} --branch=${{ env.BRANCH }}
+      - name: Deploy Docs Status Error
+        if: failure()
+        run: python ./scripts/deploy_docs_status.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_ID: ${{ github.run_id }}
+          STATE: "error"
       - name: Comment Deploy
         run: python ./scripts/deploy_docs_status.py
         env:
@@ -75,4 +83,4 @@ jobs:
           DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_ID: ${{ github.run_id }}
-          IS_DONE: "true"
+          STATE: "success"

--- a/scripts/deploy_docs_status.py
+++ b/scripts/deploy_docs_status.py
@@ -1,11 +1,12 @@
 import logging
 import re
+from typing import Literal
 
-from github import Github
+from github import Auth, Github
 from pydantic import BaseModel, SecretStr
 from pydantic_settings import BaseSettings
 
-site_domain = "asyncer.tiangolo.com"
+site_domain = "typer.tiangolo.com"
 
 
 class Settings(BaseSettings):
@@ -14,7 +15,7 @@ class Settings(BaseSettings):
     deploy_url: str | None = None
     commit_sha: str
     run_id: int
-    is_done: bool = False
+    state: Literal["pending", "success", "error"] = "pending"
 
 
 class LinkData(BaseModel):
@@ -27,7 +28,7 @@ def main() -> None:
     settings = Settings()
 
     logging.info(f"Using config: {settings.model_dump_json()}")
-    g = Github(settings.github_token.get_secret_value())
+    g = Github(auth=Auth.Token(settings.github_token.get_secret_value()))
     repo = g.get_repo(settings.github_repository)
     use_pr = next(
         (pr for pr in repo.get_pulls() if pr.head.sha == settings.commit_sha), None
@@ -38,16 +39,7 @@ def main() -> None:
     commits = list(use_pr.get_commits())
     current_commit = [c for c in commits if c.sha == settings.commit_sha][0]
     run_url = f"https://github.com/{settings.github_repository}/actions/runs/{settings.run_id}"
-    if settings.is_done and not settings.deploy_url:
-        current_commit.create_status(
-            state="success",
-            description="No Docs Changes",
-            context="deploy-docs",
-            target_url=run_url,
-        )
-        logging.info("No docs changes found")
-        return
-    if not settings.deploy_url:
+    if settings.state == "pending":
         current_commit.create_status(
             state="pending",
             description="Deploying Docs",
@@ -56,6 +48,26 @@ def main() -> None:
         )
         logging.info("No deploy URL available yet")
         return
+    if settings.state == "error":
+        current_commit.create_status(
+            state="error",
+            description="Error Deploying Docs",
+            context="deploy-docs",
+            target_url=run_url,
+        )
+        logging.info("Error deploying docs")
+        return
+    assert settings.state == "success"
+    if not settings.deploy_url:
+        current_commit.create_status(
+            state="success",
+            description="No Docs Changes",
+            context="deploy-docs",
+            target_url=run_url,
+        )
+        logging.info("No docs changes found")
+        return
+    assert settings.deploy_url
     current_commit.create_status(
         state="success",
         description="Docs Deployed",
@@ -84,7 +96,9 @@ def main() -> None:
         links.append(link)
         links.sort(key=lambda x: x.preview_link)
 
-    message = f"📝 Docs preview for commit {settings.commit_sha} at: {deploy_url}"
+    header = "## 📝 Docs preview"
+    message = header
+    message += f"\n\nLast commit {settings.commit_sha} at: {deploy_url}"
 
     if links:
         message += "\n\n### Modified Pages\n\n"
@@ -94,7 +108,17 @@ def main() -> None:
             message += "\n"
 
     print(message)
-    use_pr.as_issue().create_comment(message)
+    issue = use_pr.as_issue()
+    comments = list(issue.get_comments())
+    for comment in comments:
+        if (
+            comment.body.startswith(header)
+            and comment.user.login == "github-actions[bot]"
+        ):
+            comment.edit(message)
+            break
+    else:
+        issue.create_comment(message)
 
     logging.info("Finished")
 

--- a/scripts/deploy_docs_status.py
+++ b/scripts/deploy_docs_status.py
@@ -6,7 +6,7 @@ from github import Auth, Github
 from pydantic import BaseModel, SecretStr
 from pydantic_settings import BaseSettings
 
-site_domain = "typer.tiangolo.com"
+site_domain = "asyncer.tiangolo.com"
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
👷 Update docs previews comment, single comment, add failure status

With this, there will be a single comment with the docs preview, instead of one comment after each commit.

And now it will also update the GitHub workflow status with a failure when there's a failure deploying, instead of hanging forever.