### PR TITLE
👽️ Ensure compatibility with AnyIO 4.11.0

### DIFF
--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -306,6 +306,9 @@ def syncify(
     @functools.wraps(async_function)
     def wrapper(*args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs) -> T_Retval:
         current_async_module = (
+            getattr(getattr(threadlocals, "current_token", None), "backend_class", None)
+            or
+            # TODO: remove when deprecating AnyIO 4.10.0
             getattr(threadlocals, "current_async_backend", None)
             or
             # TODO: remove when deprecating AnyIO 3.x

--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -306,7 +306,7 @@ def syncify(
     @functools.wraps(async_function)
     def wrapper(*args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs) -> T_Retval:
         current_async_module = (
-            getattr(getattr(threadlocals, "current_token", None), "backend_class", None)
+            getattr(threadlocals, "current_token", None)
             or
             # TODO: remove when deprecating AnyIO 4.10.0
             getattr(threadlocals, "current_async_backend", None)


### PR DESCRIPTION
Recently, [our CI broke](https://github.com/fastapi/asyncer/pull/378) after the release of AnyIO 4.11.0.

In the `syncify` function implementation, we are relying on some internals of `anyio`:
```
       current_async_module = (
            getattr(threadlocals, "current_async_backend", None)
            or
            # TODO: remove when deprecating AnyIO 3.x
            getattr(threadlocals, "current_async_module", None)
        )
```
Then when `current_async_module` is not `None`, we decide we're in an async context.

In https://github.com/agronholm/anyio/pull/973 however, these internals were [changed](https://github.com/agronholm/anyio/pull/973/files#diff-2e6f8395a336ea5e45794ad82e94511baf6c7147aa1039255074efcdce07f59a).

As such, we should now be checking `threadlocals.current_token` instead.