### PR TITLE
⬆ Bump pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: trailing-whitespace
 
 -   repo: https://github.com/crate-ci/typos
-    rev: 37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
+    rev: bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # frozen: v1.48.0
     hooks:
       - id: typos
         args: [--force-exclude]


### PR DESCRIPTION
Bump pre-commit hook versions via `prek auto-update --freeze --cooldown-days 7`.